### PR TITLE
feat(ece251): add Week 09 MIPS datapath notes and HW09

### DIFF
--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -13,5 +13,11 @@ Add the lecture notes for Week 09 to the ECE 251 Computer Architecture course re
   - Added reading assignments mapping directly to the week's syllabus timeline.
 - **Fixed Typography**: Corrected unclosed HTML anchor tags (`</a>`) in `ece251-notes.md` for Weeks 12, 13, and 14 headers that resulted from previous week shifts.
 
+- **Generated Homework 09 (`hw-09.md` & `hw-09-solution.md`)**:
+  - Created a new assignment evaluating Datapath Component Utilization, Single-Cycle Instruction Tracing, and Component Latencies based on textbook exercises 4.3, 4.5, and 4.7.
+  - Tailored solution breakdowns explicitly to MIPS32 register standards and aligned mathematical explanations with `Textbook Figure 4.11`.
+- **Updated `notes_week_09.md` Latencies**: Added section `4.5 Datapath Component Latencies and Critical Paths` to support students in identifying physical execution delays.
+- **Standardized Submission Guidelines**: Updated the submission instruction text uniformly across assignments (`hw-01` through `hw-09`) to explicitly direct students to submit via Microsoft Teams instead of GitHub.
+
 ## Next Steps
 - Commit the content, push to `feature/week09-notes`, and open a Pull Request.

--- a/courses/ece251/2026/assignments/hw-04.md
+++ b/courses/ece251/2026/assignments/hw-04.md
@@ -82,4 +82,4 @@ Write a SystemVerilog module `register_n` with the following specifications:
 
 ## Submission
 
-Submit your answers as a PDF or Markdown file. For the coding problems (4 & 5), you may paste your SystemVerilog code directly into the document.
+Submit your answers as a PDF or Markdown file via the Microsoft Teams' assignment. For the coding problems (4 & 5), you may paste your SystemVerilog code directly into the document.

--- a/courses/ece251/2026/assignments/hw-05.md
+++ b/courses/ece251/2026/assignments/hw-05.md
@@ -82,4 +82,4 @@ b) Briefly explain how the MIPS hardware instructions `ll` (Load Linked) and `sc
 
 ## Submission
 
-Submit your answers as a PDF or Markdown file in the Microsoft Teams assignment tab of our course. For the coding problems (1 & 2), you may paste your SystemVerilog code directly into the document.
+Submit your answers as a PDF or Markdown file via the Microsoft Teams' assignment. For the coding problems (1 & 2), you may paste your SystemVerilog code directly into the document.

--- a/courses/ece251/2026/assignments/hw-06.md
+++ b/courses/ece251/2026/assignments/hw-06.md
@@ -77,4 +77,4 @@ To prepare for our Chapter 4 introduction to Pipelining, we must explicitly unde
 
 ## Submission
 
-Submit your answers as a PDF or Markdown file. Be sure to clearly box your final mathematical output for Problem 1.
+Submit your answers as a PDF or Markdown file via the Microsoft Teams' assignment. Be sure to clearly box your final mathematical output for Problem 1.

--- a/courses/ece251/2026/assignments/hw-07.md
+++ b/courses/ece251/2026/assignments/hw-07.md
@@ -100,4 +100,4 @@ fib_one:
 
 ## Submission
 
-Submit your answers as a PDF or Markdown file via the GitHub Classroom repository link provided directly in Microsoft Teams. Be sure to clearly box your final mathematical outputs where applicable.
+Submit your answers as a PDF or Markdown file via the Microsoft Teams' assignment. Be sure to clearly box your final mathematical outputs where applicable.

--- a/courses/ece251/2026/assignments/hw-09-solution.md
+++ b/courses/ece251/2026/assignments/hw-09-solution.md
@@ -1,0 +1,62 @@
+# Assignment 9 Solutions
+
+### Part 1: Datapath Logic & Component Utilization
+
+**1. Datapath Component Pathways (Based on textbook Ex. 4.3)**
+
+*   **A. Instruction Memory:** **100%**. 
+    *   *Explanation*: The very first mandatory phase of the Execution Cycle is the Instruction Fetch. Without pulling an instruction out of the Instruction Memory using the active Program Counter, the processor literally does not know what task it is being asked to perform. 
+*   **B. Data Memory:** **35%**.
+    *   *Explanation*: The Data Memory unit is only electrically accessed during instructions that specifically need to read a variable from RAM or write a variable to RAM. In this instruction mix, the only memory operations are Load (`lw` at 20%) and Store (`sw` at 15%). $20\% + 15\% = 35\%$. R-Type, Branches, and Jumps actively bypass Data Memory entirely by rejecting its output structurally.
+*   **C. Sign-Extend Unit:** **50%**.
+    *   *Explanation*: The Sign-Extend unit takes a 16-bit immediate value embedded inside an instruction and stretches it to 32 bits for the ALU to use in offsetting mathematics. The instructions requiring this are `lw` (20%), `sw` (15%), and `beq` (15%) because they compute 16-bit address offsets. Standard R-types (35%) do not possess an immediate field. Explicit MIPS Jump instructions (`j`) also bypass the main 16-bit sign-extender. Therefore, cumulative interaction is $20\% + 15\% + 15\% = 50\%$.
+
+---
+
+### Part 2: Single-Cycle Instruction Tracing
+
+**2. Tracing the MUXes and ALU (Based on textbook Ex. 4.5)**
+
+*   **A. MIPS Assembly Instruction Translation:**
+    *   *Hex*: `0x00c6ba22`
+    *   *Binary*: `0000 0000 1100 0110 1011 1010 0010 0010`
+    *   *Decoding via R-Type Format:* 
+        *   `Opcode` = `000000` (R-Type)
+        *   `rs` = `00110` (Register 6, which is `$A2`)
+        *   `rt` = `00110` (Register 6, which is `$A2`)
+        *   `rd` = `10111` (Register 23, which is `$S7`)
+        *   `shamt` = `01000` (8)
+        *   `funct` = `100010` (34, which mathematically commands MIPS `sub`)
+    *   **Answer**: `sub $s7, $a2, $a2`
+
+*   **B. MUX Logical Values:**
+    *   *Understanding the Diagram*: Refer to **Textbook Figure 4.11**, specifically the MUX controls stemming from the top main Control Unit blob.
+    *   **Answer**:
+        *   `ALUSrc = 0`. Because it is an R-Type `sub`, the second operand feeding the ALU must come entirely from register `rt` (the `$A2` value from the Register File path), rather than the bottom immediate sign-extended constant line.
+        *   `MemtoReg = 0`. The processor must write the result of the `sub` mathematics straight from the ALU's output wire directly back to the Register File, bypassing Data Memory entirely.
+        *   `Branch = 0`. This is an arithmetic instruction, not a `beq` instruction; the program flow will linearly not deviate from `PC + 4`.
+
+*   **C. Final Updated Program Counter:**
+    *   **Answer**: The finalized address locked in is **`0x00400014`**, which was computed purely by the **PC + 4 Adder** located at the top left of the Chapter 4 datapath. Because the `Branch = 0` signal triggered the highest final MUX to select the logic `0` pathway, the secondary branch-target adder generated output is physically ignored.
+
+---
+
+### Part 3: Timing & Critical Paths
+
+**3. Datapath Component Latencies (Based on textbook Ex. 4.7)**
+
+*   **A. R-Type Latency Calculation:**
+    *   *Explanation*: To trace latency, follow the exact electrical path drawn traversing textbook Figure 4.11. Start at the PC, travel through Instruction Memory, down into the Registers, out the top line into the ALUSrc MUX to hit the ALU, then travel natively out of the ALU and thread strictly back into the Register File Write port, locking the state.
+    *   *Pathway:* `PC Clock-to-Q` -> `Instruction Memory` -> `Register Read` -> `ALUSrc MUX` -> `ALU` -> `MemtoReg MUX` -> `Register Setup Time`
+    *   *Math:* $30 + 250 + 150 + 25 + 200 + 25 + 20$
+    *   **Answer:** **700 ps**
+
+*   **B. Load Word (`lw`) Latency Calculation:**
+    *   *Explanation*: For a load word, the ALU computes an address offset. Therefore, its output must flow completely THROUGH the entire Data Memory unit sequentially before it can loop back to the Register File.
+    *   *Pathway:* `PC Clock-to-Q` -> `Instruction Memory` -> `Register Read` -> `ALUSrc MUX` -> `ALU` -> `Data Memory Read` -> `MemtoReg MUX` -> `Register Setup Time`
+    *   *Math:* $30 + 250 + 150 + 25 + 200 + 250 + 25 + 20$
+    *   **Answer:** **950 ps**
+
+*   **C. Universal Clock Cycle Requirement:**
+    *   **Answer**: The Clock Cycle Time MUST be hard-locked at **950 ps**. 
+    *   *Explanation*: In a Single-Cycle hardware design, the processor clock provides one unyielding drumbeat across the silicon. State elements exclusively capture results right on the upward edge of that beat. In order to guarantee the processor never accidentally captures a "half-finished" electrical pulse on highly complex instructions like `lw` (which takes 950 ps to clear its final wire and arrive at the Reg Setup), the entire clock cycle must be globally set to safely accommodate that longest, worst-case latency scenario. Faster instructions (like the 700ps R-Type) simply finish calculating early and physically sit electrically idle for the remaining 250ps waiting for the eventual clock pulse to trigger their write.

--- a/courses/ece251/2026/assignments/hw-09.md
+++ b/courses/ece251/2026/assignments/hw-09.md
@@ -1,0 +1,89 @@
+# Assignment 9
+
+<5 points>
+
+### Homework Pointing Scheme
+
+| Total points | Explanation |
+| -----------: | :---------- |
+|            0 | Not handed in |
+|            1 | Handed in late |
+|            2 | Handed in on time, not every problem fully worked through and clearly identifying the solution |
+|            3 | Handed in on time, each problem answered a boxed answer, each problems answered with a clearly worked through solution, and **less than majority** of problems answered correctly |
+|            4 | Handed in on time, **majority** of problems answered correctly, each solution boxed clearly, and each problem fully worked through |
+|            5 | Handed in on time, every problem answered correctly, every solution boxed clearly, and every problem fully worked through. |
+
+## Reading
+
+*   **Notes**: [Week 9 Notes](/courses/ece251/2026/weeks/week_09/notes_week_09.html)
+*   **Reference**: *Computer Organization and Design* (6th Ed.) - Chapter 4
+
+## Problem Set
+
+### Part 1: Datapath Logic & Component Utilization
+
+**1. Datapath Component Pathways (Based on textbook Ex. 4.3)**
+
+**Goal**: Understand structural hardware efficiency depending dynamically on the instruction workload.
+
+Consider a baseline MIPS processor executing a computationally heavy application with the following instruction mix: 
+*   **35%** ALU (R-type operations like `add`, `sub`)
+*   **20%** Load (`lw`)
+*   **15%** Store (`sw`)
+*   **15%** Branch (`beq`)
+*   **15%** Jump (`j`)
+
+Using this specific instruction mix, calculate the overall fractional utilization for the following major datapath elements during the application's runtime. Show your component tracing logic based on whether each instruction type activates it.
+*   **A.** The **Instruction Memory** unit.
+*   **B.** The **Data Memory** unit.
+*   **C.** The **Sign-Extend** unit.
+
+---
+
+### Part 2: Single-Cycle Instruction Tracing
+
+**2. Tracing the MUXes and ALU (Based on textbook Ex. 4.5)**
+
+**Goal**: Trace specific, bit-level hardware controls that trigger sequentially inside the processor during a single clock cycle.
+
+Assume it is the start of a clock cycle. The Program Counter (PC) currently holds the address `0x00400010`. The processor fetches the following 32-bit machine code instruction word from Instruction Memory: 
+`0x00c6ba22`
+
+*(Hint: first decode this native hex into binary, and parse it strictly using the MIPS 32-bit instruction formats: Opcode, rs, rt, rd, shamt, funct).*
+
+*   **A.** What exact MIPS assembly instruction does this hex code represent?
+*   **B.** To successfully execute this instruction, what specific logical values (`0` or `1`) must the Main Control Unit broadcast to the three primary Multiplexers (MUXes): `ALUSrc`, `MemtoReg`, and `Branch`?
+*   **C.** What is the final updated value of the Program Counter (PC) safely locked in at the very end of this clock cycle (written in hex)? Name the specific Datapath Adder that mathematically computed this finalized value.
+
+---
+
+### Part 3: Timing & Critical Paths
+
+**3. Datapath Component Latencies (Based on textbook Ex. 4.7)**
+
+**Goal**: Calculate pure hardware latency using the critical path delays of logic gates, leading into the requirement for pipelining.
+
+Assume you are given raw silicon components with the exact following hardware delay latencies required to physically stabilize a signal:
+
+| Component | Latency Delay |
+| :--- | :--- |
+| **I-Mem (Instruction Fetch)** | 250 ps |
+| **D-Mem (Data Memory Read/Write)** | 250 ps |
+| **ALU (Math execution)** | 200 ps |
+| **PC/Adders (Address computation)** | 150 ps |
+| **Register File (Read or Setup Write)** | 150 ps |
+| **Multiplexer (MUX toggle)** | 25 ps |
+| **Sign-Extend Unit** | 20 ps |
+| **Logic Gates (e.g. AND gate)** | 5 ps |
+| **PC Register (`clk`-to-Q trigger)** | 30 ps |
+| **PC Register / Reg File Setup Time** | 20 ps |
+
+*   **A.** Calculate the cumulative critical path execution latency (in picoseconds) logically required to safely execute a standard MIPS R-Type instruction (like `add`). 
+*   **B.** Calculate the cumulative critical path execution latency required to logically execute a Load Word (`lw`) instruction. 
+*   **C.** Using the timing rules of Single-Cycle Datapath Design, what MUST the processor's universal Clock Cycle time be locked at to guarantee functional stability across the entire ISA? Explain why.
+
+---
+
+## Submission
+
+Submit your answers as a PDF or Markdown file via the Microsoft Teams' assignment. Be sure to clearly box your final mathematical outputs where applicable.

--- a/courses/ece251/2026/weeks/week_09/notes_week_09.md
+++ b/courses/ece251/2026/weeks/week_09/notes_week_09.md
@@ -136,6 +136,29 @@ endmodule
 
 These modules, alongside array-based Instruction/Data memories, are wired together structurally in a top-level wrapper (e.g., `mips_single_cycle.sv`) strictly following the data flow shown in **textbook Figure 4.11**. A testbench then supplies the `clk` and `reset` signals, computationally driving the entire emulated processor.
 
+#### 4.5 Datapath Component Latencies and Critical Paths
+To truly understand the performance limitations of the single-cycle processor architecture, we must quantify the physical timing delays of the hardware components. Every gate, multiplexer, and memory unit takes a fraction of a nanosecond to stabilize its electrical output after its inputs arrive. This delay is the component's **latency**.
+
+Assume a processor is built with components having the following latencies (measured in picoseconds, ps):
+*   **Instruction Memory (I-Mem)**: `250 ps`
+*   **Data Memory (D-Mem)**: `250 ps`
+*   **Register File (Read or Write)**: `150 ps`
+*   **ALU (Math & Logic)**: `200 ps`
+*   **Programmable Adders (e.g., PC+4)**: `150 ps`
+*   **Multiplexers (MUX)**: `25 ps`
+*   **Sign-Extension Unit**: `20 ps`
+*   **Program Counter (PC) Register (Clock-to-Q)**: `30 ps`
+
+To calculate the total latency of a specific instruction type, we mathematically trace its *longest sequential electrical path*:
+1.  **R-Type Instruction (e.g., `add $t0, $t1, $t2`)**:
+    - `PC` (30ps) -> `I-Mem` (250ps) -> `Reg Read` (150ps) -> `ALUSrc MUX` (25ps) -> `ALU` (200ps) -> `MemtoReg MUX` (25ps) -> `Reg Write Setup` (20ps) = **700 ps**
+2.  **Load Word (`lw`) Instruction**:
+    - `PC` (30ps) -> `I-Mem` (250ps) -> `Reg Read` (150ps) -> `ALUSrc MUX` (25ps) -> `ALU` (200ps) -> `D-Mem Read` (250ps) -> `MemtoReg MUX` (25ps) -> `Reg Write Setup` (20ps) = **950 ps**
+3.  **Branch (`beq`) Instruction**:
+    - `PC` (30ps) -> `I-Mem` (250ps) -> `Reg Read` (150ps) -> `ALU subtraction` (200ps) -> `Branch MUX` (25ps) -> `PC Setup` (20ps) = **675 ps** *(Requires small AND gate delay in ISA specific implementations)*
+
+Because the single-cycle machine uses one universal clock to drive all operations, the globally defined **Clock Cycle Time** MUST precisely accommodate the longest possible latency of any instruction in the ISA (`lw` at **950 ps**).
+
 ### Tracking Processor Components and System Integration
 
 Before looking at complete problem walkthroughs, we should explicitly track the primary individual components needed to physically construct our MIPS processor, as well as what is required to transform this raw processor into a fully functional general-purpose computer.


### PR DESCRIPTION
# Pull Request Summary: Week 09 Notes

## Intended Changes
Add the lecture notes for Week 09 to the ECE 251 Computer Architecture course repository, focusing on the processor datapath, logical design conventions, and SystemVerilog behavioral emulation.

## Implementation Details
- **Created `courses/ece251/2026/weeks/week_09/notes_week_09.md`**:
  - Implemented deep dives for Textbook Chapter 4 (Sections 4.1 to 4.3).
  - Explicitly mapped the Session 1-8 syllabus timeline to the fundamental structural datapath components required to emulate the single-cycle machine.
  - Linked specific textbook Datapath logic figures (`Textbook Figure 4.1`, `4.2`, `4.5`, `4.6`, `4.7`, `4.11`) to visual assets in `/Image Bank`.
  - Authored a dedicated subsection for SystemVerilog behavioral modeling of the Program Counter, Register File, and ALU to bridge theoretical logic concepts with practical RTL programming.
  - Supplied three complete problem walkthroughs mapping back to Chapter 4 textbook exercises (Simple - Ex 4.3 Component Utilization, Medium - Ex 4.1 Control Signals, Hard - Ex 4.4 Diagnosing Stuck Control Multiplexers).
  - Added reading assignments mapping directly to the week's syllabus timeline.
- **Fixed Typography**: Corrected unclosed HTML anchor tags (`</a>`) in `ece251-notes.md` for Weeks 12, 13, and 14 headers that resulted from previous week shifts.

- **Generated Homework 09 (`hw-09.md` & `hw-09-solution.md`)**:
  - Created a new assignment evaluating Datapath Component Utilization, Single-Cycle Instruction Tracing, and Component Latencies based on textbook exercises 4.3, 4.5, and 4.7.
  - Tailored solution breakdowns explicitly to MIPS32 register standards and aligned mathematical explanations with `Textbook Figure 4.11`.
- **Updated `notes_week_09.md` Latencies**: Added section `4.5 Datapath Component Latencies and Critical Paths` to support students in identifying physical execution delays.
- **Standardized Submission Guidelines**: Updated the submission instruction text uniformly across assignments (`hw-01` through `hw-09`) to explicitly direct students to submit via Microsoft Teams instead of GitHub.

## Next Steps
- Commit the content, push to `feature/week09-notes`, and open a Pull Request.
