### PR TITLE
docs: Formalize Week 13 Cache Curriculum Expansion

### DIFF
--- a/courses/ece251/2026/weeks/week_13/PR_SUMMARY.md
+++ b/courses/ece251/2026/weeks/week_13/PR_SUMMARY.md
@@ -1,0 +1,30 @@
+# PR Summary: Week 13 Cache Curriculum Expansion
+
+## Objective
+The objective of this update is to finalize the Week 13 Memory Hierarchies curriculum for ECE 251. We aim to bridge abstract architectural theory with practical physical hardware realities, specifically focusing on cache topologies, DRAM mechanics, and foundational SystemVerilog implementations.
+
+## Changes Made
+
+### 1. Markdown Notes (`notes_week_13.md`)
+*   **Expanded Topologies:** Added deep-dive explanations of Direct-Mapped, Fully Associative, and Set-Associative caches.
+*   **Historical Context:** Injected "The Journey So Far" narrative, contextualizing the memory system as the crucial counterpart to our pipelined processor.
+*   **Textbook Synthesis:** Integrated concepts from both Harris (Desk Analogy, AMAT) and Hamacher (Write Policies, Interleaving).
+*   **Hardware Reality (DRAM):** Added a breakdown of 1T1C cells, destructive reads, and RAS/CAS multiplexing.
+*   **SystemVerilog Models:** Interleaved a 3-stage hardware progression:
+    *   Level 1: Basic Synchronous Main Memory.
+    *   Level 2: Direct-Mapped Cache Arrays (`Data`, `Tag`, `Valid`).
+    *   Level 3: Combinational Hit/Miss Logic.
+*   **Practice Problems:** Added a tiered (Easy/Medium/Hard) problem set using `<details>` blocks.
+
+### 2. Lecture Slides (`ece251_week_13_slides.tex`)
+*   Added parallel content to visually support the notes.
+*   Included verbatim blocks containing the SystemVerilog progression.
+*   Successfully recompiled PDF (extended to 23 frames).
+
+### 3. Architecture Diagrams (`TECH_DESIGN.md`)
+*   Created Mermaid UML sequence and block diagrams mapping out the DRAM refresh loop, Cache hit logic, and overall system architecture.
+
+## Verification
+*   LaTeX slide deck successfully compiled without fatal errors.
+*   Mermaid diagrams validated for syntax correctness.
+*   Markdown previewed successfully.

--- a/courses/ece251/2026/weeks/week_13/TECH_DESIGN.md
+++ b/courses/ece251/2026/weeks/week_13/TECH_DESIGN.md
@@ -1,0 +1,63 @@
+# Memory System Technical Architecture
+
+This document maps out the logical and temporal architecture of the memory subsystems introduced in Week 13.
+
+## 1. System Architecture (Block Diagram)
+
+```mermaid
+graph TD
+    CPU[MIPS Pipelined CPU] <-->|Address / Data| Cache[L1 Direct-Mapped Cache]
+    Cache <-->|Miss: Fetch Block| MemCtrl[Memory Controller]
+    MemCtrl <-->|RAS/CAS / Refresh| DRAM[(Main Memory 1T1C)]
+```
+
+## 2. Direct-Mapped Hit/Miss Logic (Sequence Diagram)
+
+This diagram maps the SystemVerilog `cache_controller` module's execution sequence.
+
+```mermaid
+sequenceDiagram
+    participant CPU
+    participant CacheCtrl as Cache Controller
+    participant Arrays as Cache Arrays (Tag/Data/Valid)
+    participant Mem as Main Memory
+
+    CPU->>CacheCtrl: Request Address (Tag, Index, Offset)
+    CacheCtrl->>Arrays: Read Tag and Valid bit at [Index]
+    Arrays-->>CacheCtrl: Return stored_tag, is_valid
+    
+    alt cache_hit = 1 (Valid & Tag Match)
+        CacheCtrl->>Arrays: Read Data at [Index]
+        Arrays-->>CacheCtrl: Return cache_data
+        CacheCtrl-->>CPU: Data Ready (No Stall)
+    else cache_hit = 0 (Miss)
+        CacheCtrl-->>CPU: Stall Pipeline!
+        CacheCtrl->>Mem: Fetch Block at Address
+        Mem-->>CacheCtrl: Return Block (Miss Penalty Latency)
+        CacheCtrl->>Arrays: Write Tag, Set Valid=1, Write Data
+        CacheCtrl-->>CPU: Release Stall, Data Ready
+    end
+```
+
+## 3. DRAM Refresh Cycle (Flowchart)
+
+Because of the volatile nature of the 1T1C capacitor, a hardware timer must periodically interrupt normal operations to execute a refresh.
+
+```mermaid
+flowchart TD
+    Start[Timer reaches 64ms] --> Stall[Memory Controller Stalls CPU requests]
+    Stall --> SetRow[Set Row Counter = 0]
+    
+    ReadRow[Assert RAS: Read Row into Sense Amps]
+    Rewrite[Assert WE: Sense Amps Rewrite Row to Capacitors]
+    IncRow[Increment Row Counter]
+    Check{Row Counter < Max Rows?}
+    
+    SetRow --> ReadRow
+    ReadRow --> Rewrite
+    Rewrite --> IncRow
+    IncRow --> Check
+    
+    Check -- Yes --> ReadRow
+    Check -- No --> Done[Release CPU Stall]
+```

--- a/courses/ece251/2026/weeks/week_13/TODO.md
+++ b/courses/ece251/2026/weeks/week_13/TODO.md
@@ -1,0 +1,11 @@
+# Week 13 / Memory Hierarchy TODOs
+
+## Immediate Future Work (Week 14)
+- [ ] **Miss Penalty FSM:** We stopped the SystemVerilog implementation at the combinational hit logic. We need to implement the Finite State Machine that stalls the CPU, triggers the fetch from Main Memory, writes the block into the cache, and resumes the CPU.
+- [ ] **Virtual Memory:** Prepare notes and slides for Section 5.6 (Virtual Memory, Page Tables).
+- [ ] **TLB (Translation Lookaside Buffer):** Explain how a cache for the page table dramatically speeds up translation.
+
+## Final Project Integration
+- [ ] Update the `final_project/GUIDE.md` to introduce the Cache Controller requirement.
+- [ ] Provide students with a `tb_memory.sv` wrapper that forces a cache miss latency (e.g., 50 cycles) to test if their pipelined CPU stall logic actually works.
+- [ ] Define the exact associativity (e.g., Direct-Mapped) required for the Final Project.


### PR DESCRIPTION
Adds PR_SUMMARY.md, TODO.md, and TECH_DESIGN.md (with Mermaid diagrams) to document the Week 13 curriculum expansion for memory hierarchies, caches, and DRAM.